### PR TITLE
add rAAAreware as MQTT vendor

### DIFF
--- a/_sites/software.md
+++ b/_sites/software.md
@@ -621,6 +621,7 @@ description: A collection of links to all important MQTT brokers/servers, MQTT c
             <li><a href="http://www.choral.it">Choral</a> - Choral GPS/GSM tracking module (check which models have MQTT)</li>
             <li><a href="https://www.lindsay.com/lam/en/irrigation/brands/elecsys/our-solutions/monitoring-control-solutions/oil-gas-water/industrial-data-communications/">Elecsys</a> - Elecsys Industrial Communications Gateway and Remote Monitors</li>
             <li><a href="https://www.flukso.net/">Flukso</a> - Fluksometer, an electricity metering device with native MQTT support</li>
+            <li><a href="http://raaareware.de/">rAAAreware</a> - MQTT modules for handheld measuring devices, MQTT displays, MQTT remote control</li>
             <li><a href="http://www.remakeelectric.com/">ReMake</a> - ReMake Electric electricity metering systems publish all readings to the on-device MQTT broker.</li>
             <li><a href="http://www.owasys.com">Owasys</a> - The owa11 model is an IP67 asset tracking and telemetry unit reporting location, events and IO information using MQTT</li>
             <li><a href="https://www.umh.app">United Manufacturing Hub</a> - The Open-Source toolkit to build your own reliable and secure Industrial IoT platform (strongly leverages MQTT in the Industrial IoT)</li>


### PR DESCRIPTION
rAAAreware is a "MQTT-only" vendor of wlan modules for measuring devices. 
Entry page is in german language but there are some languages supported by toolbar selection.