### PR TITLE
Add MQMGateway

### DIFF
--- a/_sites/software.md
+++ b/_sites/software.md
@@ -611,6 +611,7 @@ description: A collection of links to all important MQTT brokers/servers, MQTT c
             <li><a href="https://github.com/Koenkk/zigbee2mqtt">zigbee2mqtt</a> - ZigBee gateway that exposes ZigBee certified devices (Philis Hue, Xiaomi Aqara, ...) via mqtt. Commonly used for home automation. <a href="https://www.zigbee2mqtt.io/information/supported_devices.html">list of supported devices</a></li>
             <li><a href="https://mqtt.cool">MQTT.Cool</a> - A web gateway that optimizes any MQTT broker when sending real-time data to web clients with automatic throttling.</li>
             <li><a href="https://neugates.io/">Neuron</a> - An open-source, lightweight IIoT connectivity server that convert industrial protocol to MQTT, SparkPlugB etc.</li>
+            <li><a href="https://github.com/BlackZork/mqmgateway">MQM Gateway</a> - An open-source, lightweight C++ bidirectional Modbus RTU/TCP <=> MQTT Gateway with flexible data conversion on the fly</li>
          </ul>
          <div class="subhead">Misc</div>
             <ul>


### PR DESCRIPTION
An open-source, lightweight C++ bidirectional Modbus RTU/TCP <=> MQTT Gateway with flexible data conversion on the fly.