### PR TITLE
Updated the name from FlowForge to FlowFuse

### DIFF
--- a/_sites/software.md
+++ b/_sites/software.md
@@ -572,7 +572,7 @@ description: A collection of links to all important MQTT brokers/servers, MQTT c
    <div class="panel">
       <div class="subhead">Web</div>
          <ul>
-            <li><a href="https://flowforge.com/">FlowForge</a> - is a hosted Node-RED platform that allows you to easily create MQTT applications using low-code and visual programming. </li>
+            <li><a href="https://flowFuse.com/">FlowFuse</a> - is a secure hosted Node-RED platform that allows you to easily create MQTT applications using low-code and visual programming. </li>
             <li><a href="https://mqttboard.flespi.io">MQTT Board</a> - diagnostic oriented MQTT 5.0 client tool based on <a href="https://github.com/mqttjs">mqtt.js</a>. Available in <a href="https://github.com/flespi-software/mqtt-board">open source</a>.</li>
             <li><a href="https://mqtttiles.flespi.io">MQTT Tiles</a> - <a href="https://github.com/flespi-software/MQTT-Tiles">Open source</a> MQTT-based dashboard visualization tool.</li>
             <li><a href="http://test.mosquitto.org/ws.html">MQTT over websockets</a> (experimental) - from the mosquitto project.</li>


### PR DESCRIPTION
About 6 months ago FlowForge changed their name to FlowFuse.  Updating the site to reflect that change.