### PR TITLE
Improve sponsor link markup

### DIFF
--- a/_sites/faq.md
+++ b/_sites/faq.md
@@ -9,7 +9,7 @@ description: Frequently asked questions about MQTT and a dictionary of terms and
 <div class="accordion-wrapper" style="margin-bottom: 50px;">
    <button class="accordion">What is MQTT?</button>
    <div class="panel">
-      <p>MQTT is an OASIS standard for IoT connectivity. It is a publish/subscribe, extremely simple and lightweight messaging protocol, designed for constrained devices and low-bandwidth, high-latency or unreliable networks. The design principles are to minimise network bandwidth and device resource requirements whilst also attempting to ensure reliability and some degree of assurance of delivery. These principles also turn out to make the protocol ideal of the “Internet of Things” world of connected devices, and for mobile applications where bandwidth and battery power are at a premium.</p>
+      <p>MQTT is an OASIS standard for IoT connectivity. It is a publish/subscribe, extremely simple and lightweight messaging protocol, designed for constrained devices and low-bandwidth, high-latency or unreliable networks. The design principles are to minimise network bandwidth and device resource requirements whilst also attempting to ensure reliability and some degree of assurance of delivery. These principles also turn out to make the protocol ideal for the “Internet of Things” world of connected devices, and for mobile applications where bandwidth and battery power are at a premium.</p>
    </div>
    <button class="accordion">Who invented MQTT?</button>
    <div class="panel">

--- a/_sites/mqtt-specification.md
+++ b/_sites/mqtt-specification.md
@@ -51,15 +51,15 @@ MQTT is an OASIS standard. The specification is managed by the OASIS MQTT Techni
    <div class="floating-right">
    <h2>TC Member Organizations</h2>
    <div id="tc-members">
-         <a href="https://www.cisco.com/" target="_blank"><img src=" {{ 'assets/img/tc-cisco.png' | relative_url }}" class="tc-logo" alt="Cisco logo" title="Cisco"></a>
-         <a href="https://www.emqx.com/en" target="_blank"><img src=" {{ 'assets/img/tc-emq.png' | relative_url }}" class="tc-logo" alt="EMQ logo" title="EMQ"></a>
-         <a href="https://www.hivemq.com" target="_blank" ><img src=" {{ 'assets/img/tc-hivemq.png' | relative_url }}" class="tc-logo" alt="HiveMQ logo" title="HiveMQ"></a>
-         <a href="https://www.ibm.com" target="_blank"><img src=" {{ 'assets/img/tc-ibm.png' | relative_url }}" class="tc-logo" alt="IBM logo" title="IBM"></a>
-         <a href="https://www.microsoft.com" target="_blank"><img src=" {{ 'assets/img/tc-microsoft.png' | relative_url }}" class="tc-logo" alt="Microsoft logo" title="Microsoft"></a>
-         <a href="https://www.ninefx.com" target="_blank"><img src=" {{ 'assets/img/tc-ninefx.png' | relative_url }}" class="tc-logo" alt="Ninefx Logo logo" title="Ninefx"></a>
-         <a href="https://www.softwareag.com/" target="_blank"><img src=" {{ 'assets/img/tc-software-ag.png' | relative_url }}" class="tc-logo" alt="Software-AG logo" title="Software-AG"></a>
-         <a href="https://www.solace.com/" target="_blank"><img src=" {{ 'assets/img/tc-solace.png' | relative_url }}" class="tc-logo" alt="Solace logo" title="Solace"></a>
-         <a href="https://thingstream.io/" target="_blank"><img src=" {{ 'assets/img/tc-thingstream.png' | relative_url }}" class="tc-logo" alt="Thingstream logo" title="Thingstream"></a>
+         <a href="https://www.cisco.com/" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-cisco.png' | relative_url }}" class="tc-logo" alt="Cisco logo" title="Cisco"></a>
+         <a href="https://www.emqx.com/en" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-emq.png' | relative_url }}" class="tc-logo" alt="EMQ logo" title="EMQ"></a>
+         <a href="https://www.hivemq.com" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-hivemq.png' | relative_url }}" class="tc-logo" alt="HiveMQ logo" title="HiveMQ"></a>
+         <a href="https://www.ibm.com" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-ibm.png' | relative_url }}" class="tc-logo" alt="IBM logo" title="IBM"></a>
+         <a href="https://www.microsoft.com" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-microsoft.png' | relative_url }}" class="tc-logo" alt="Microsoft logo" title="Microsoft"></a>
+         <a href="https://www.ninefx.com" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-ninefx.png' | relative_url }}" class="tc-logo" alt="Ninefx logo" title="Ninefx"></a>
+         <a href="https://www.softwareag.com/" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-software-ag.png' | relative_url }}" class="tc-logo" alt="Software-AG logo" title="Software-AG"></a>
+         <a href="https://www.solace.com/" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-solace.png' | relative_url }}" class="tc-logo" alt="Solace logo" title="Solace"></a>
+         <a href="https://thingstream.io/" target="_blank" rel="noopener noreferrer"><img src=" {{ 'assets/img/tc-thingstream.png' | relative_url }}" class="tc-logo" alt="Thingstream logo" title="Thingstream"></a>
    </div>
          <a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=mqtt"><button class="major-cta major-cta-orange" style="margin: 25px 0;">Join the Technical Committee</button></a>
    </div>

--- a/_sites/software.md
+++ b/_sites/software.md
@@ -290,7 +290,7 @@ description: A collection of links to all important MQTT brokers/servers, MQTT c
       </div>
    <!-- Entry -->
       <div class="panel-item">
-         <img src="{{ 'assets/img/software/waterstream.png' | relative_url }}" class="software-logo" alt="Waterstrean Logo">
+         <img src="{{ 'assets/img/software/waterstream.png' | relative_url }}" class="software-logo" alt="Waterstream Logo">
          <div class="panel-item-description"><a href="http://waterstream.io/"><h3>Waterstream</h3></a>
          Waterstream is the first and the only MQTT platform on the market leveraging Apache Kafka as its own storage and distribution engine. Every incoming MQTT message is immediately available in your microservices architecture or your analytics platform without any further processing. Vice-versa, every message written on a Kafka topic it’s sent to MQTT clients. All the necessary MQTT state, like subscriptions and QoS message status is also stored in Kafka—no need for additional storage.
          </div>


### PR DESCRIPTION
﻿## Summary
- Add `rel="noopener noreferrer"` to Technical Committee sponsor links that open in a new tab
- Fix two small copy/alt-text typos

## Verification
- `git diff --check`

I could not run `bundle exec jekyll build` because Bundler is not installed in this environment.
